### PR TITLE
stt-to-storage: UX - Move speechToText from state to storage.

### DIFF
--- a/src/components/Option/Settings/general-settings.tsx
+++ b/src/components/Option/Settings/general-settings.tsx
@@ -16,9 +16,13 @@ import {
 import { useStorage } from "@plasmohq/storage/hook"
 
 export const GeneralSettings = () => {
-  const { clearChat, speechToTextLanguage, setSpeechToTextLanguage } =
+  const { clearChat } =
     useMessageOption()
 
+  const [ speechToTextLanguage, setSpeechToTextLanguage ] = useStorage(
+      "speechToTextLanguage",
+      "en-US"
+    )
   const [copilotResumeLastChat, setCopilotResumeLastChat] = useStorage(
     "copilotResumeLastChat",
     false

--- a/src/components/Sidepanel/Settings/body.tsx
+++ b/src/components/Sidepanel/Settings/body.tsx
@@ -53,7 +53,10 @@ export const SettingsBody = () => {
   const [hideCurrentChatModelSettings, setHideCurrentChatModelSettings] =
     useStorage("hideCurrentChatModelSettings", false)
 
-  const { speechToTextLanguage, setSpeechToTextLanguage } = useMessage()
+  const [ speechToTextLanguage, setSpeechToTextLanguage ] = useStorage(
+    "speechToTextLanguage",
+    "en-US"
+  )
   const { mode, toggleDarkMode } = useDarkMode()
 
   const { changeLocale, locale, supportLanguage } = useI18n()

--- a/src/hooks/useMessage.tsx
+++ b/src/hooks/useMessage.tsx
@@ -74,8 +74,6 @@ export const useMessage = () => {
     setChatMode,
     setIsEmbedding,
     isEmbedding,
-    speechToTextLanguage,
-    setSpeechToTextLanguage,
     currentURL,
     setCurrentURL
   } = useStoreMessage()
@@ -1230,8 +1228,6 @@ export const useMessage = () => {
     chatMode,
     setChatMode,
     isEmbedding,
-    speechToTextLanguage,
-    setSpeechToTextLanguage,
     regenerateLastMessage,
     webSearch,
     setWebSearch,

--- a/src/store/option.tsx
+++ b/src/store/option.tsx
@@ -49,8 +49,6 @@ type State = {
   setChatMode: (chatMode: "normal" | "rag") => void
   isEmbedding: boolean
   setIsEmbedding: (isEmbedding: boolean) => void
-  speechToTextLanguage: string
-  setSpeechToTextLanguage: (language: string) => void
   webSearch: boolean
   setWebSearch: (webSearch: boolean) => void
   isSearchingInternet: boolean


### PR DESCRIPTION
Using non-english Speech To Text is troublesome resetting the language every time one opens the plugin. 