### PR TITLE
feat: Set Ollama URL from ollamaInfo in PlaygroundEmpty

### DIFF
--- a/src/components/Option/Playground/PlaygroundEmpty.tsx
+++ b/src/components/Option/Playground/PlaygroundEmpty.tsx
@@ -39,6 +39,13 @@ export const PlaygroundEmpty = () => {
     enabled: checkOllamaStatus
   })
 
+  useEffect(() => {
+    if (ollamaInfo?.ollamaURL) {
+      setOllamaURL(ollamaInfo.ollamaURL)
+    }
+  }, [ollamaInfo])
+
+
   if (!checkOllamaStatus) {
     return (
       <div className="mx-auto sm:max-w-xl px-4 mt-10">


### PR DESCRIPTION
### **Description:**

Added a `useEffect` hook in the `PlaygroundEmpty` component to set the `Ollama URL` from the `ollamaInfo` object. This ensures the component updates the URL whenever `ollamaInfo` changes.

### **Changes:**
- Set `ollamaURL` state based on `ollamaInfo.ollamaURL`.