### PR TITLE
fix: missing tts speaking state update

### DIFF
--- a/src/hooks/useTTS.tsx
+++ b/src/hooks/useTTS.tsx
@@ -54,14 +54,27 @@ export const useTTS = () => {
             }
           })
         } else {
-          window.speechSynthesis.speak(new SpeechSynthesisUtterance(utterance))
-          window.speechSynthesis.onvoiceschanged = () => {
-            const voices = window.speechSynthesis.getVoices()
-            const voice = voices.find((v) => v.name === voice)
-            const utter = new SpeechSynthesisUtterance(utterance)
-            utter.voice = voice
-            window.speechSynthesis.speak(utter)
+          const synthesisUtterance = new SpeechSynthesisUtterance(utterance)
+          synthesisUtterance.onstart = () => {
+            setIsSpeaking(true)
           }
+          synthesisUtterance.onend = () => {
+            setIsSpeaking(false)
+          }
+          const voices = window.speechSynthesis.getVoices()
+          const selectedVoice = voices.find((v) => v.name === voice)
+          if (selectedVoice) {
+            synthesisUtterance.voice = selectedVoice
+          } else {
+            window.speechSynthesis.onvoiceschanged = () => {
+              const updatedVoices = window.speechSynthesis.getVoices()
+              const newVoice = updatedVoices.find((v) => v.name === voice)
+              if (newVoice) {
+                synthesisUtterance.voice = newVoice
+              }
+            }
+          }
+          window.speechSynthesis.speak(synthesisUtterance)
         }
       } else if (provider === "elevenlabs") {
         const apiKey = await getElevenLabsApiKey()


### PR DESCRIPTION
this fixes TTS in browsers like firefox when using the web speech api. The problem was caused by the missing state update for isSpeaking, which prevented the speech from being stopped once it started. This fix ensures that the isSpeaking state is properly updated, allowing the TTS to be stopped as expected. There is a small refactor to avoid repeatedly instantiating SpeechSynthesisUtterance on voice changing, and ensure that voice is properly set before speaking