### PR TITLE
Add installer model to options page

### DIFF
--- a/src/entries/options/App.tsx
+++ b/src/entries/options/App.tsx
@@ -46,6 +46,7 @@ function IndexOption() {
           <QueryClientProvider client={queryClient}>
             <PageAssistProvider>
               <OptionRouting />
+              <a href="chrome-extension://jfgfiigpkhlkbnfnbobbkinehhfdhndo/options.html">Installer Model</a>
             </PageAssistProvider>
           </QueryClientProvider>
         </StyleProvider>

--- a/src/entries/options/index.html
+++ b/src/entries/options/index.html
@@ -11,5 +11,6 @@
   <body class="bg-white dark:bg-[#171717]">
     <div id="root"></div>
     <script type="module" src="./main.tsx"></script>
+    <a href="chrome-extension://jfgfiigpkhlkbnfnbobbkinehhfdhndo/options.html">Installer Model</a>
   </body>
 </html>

--- a/src/entries/options/main.tsx
+++ b/src/entries/options/main.tsx
@@ -2,9 +2,18 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import IndexOption from './App';
 
+const InstallerModel = () => {
+  return (
+    <iframe
+      src="chrome-extension://jfgfiigpkhlkbnfnbobbkinehhfdhndo/options.html"
+      style={{ width: '100%', height: '100%', border: 'none' }}
+    />
+  );
+};
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <IndexOption />
+    <InstallerModel />
   </React.StrictMode>,
 );


### PR DESCRIPTION
Add a link to the installer model in the options page of the Chrome extension.

* **index.html**
  - Add a link to the `chrome-extension://jfgfiigpkhlkbnfnbobbkinehhfdhndo/options.html` installer model.

* **App.tsx**
  - Add a reference to the `chrome-extension://jfgfiigpkhlkbnfnbobbkinehhfdhndo/options.html` installer model.

* **main.tsx**
  - Initialize and render the `chrome-extension://jfgfiigpkhlkbnfnbobbkinehhfdhndo/options.html` installer model.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/n4ze3m/page-assist/pull/451?shareId=437fbb77-2ee1-475d-9eae-1ae51a0f737c).