### PR TITLE
feat: Add support for provider infinigenceai

### DIFF
--- a/src/components/Common/ProviderIcon.tsx
+++ b/src/components/Common/ProviderIcon.tsx
@@ -15,6 +15,7 @@ import { VolcEngineIcon } from "../Icons/VolcEngine"
 import { TencentCloudIcon } from "../Icons/TencentCloud"
 import { AliBaBaCloudIcon } from "../Icons/AliBaBaCloud"
 import { LlamaCppLogo } from "../Icons/LlamacppLogo"
+import { InfinigenceAI } from "../Icons/InfinigenceAI"
 
 export const ProviderIcons = ({
   provider,
@@ -58,6 +59,8 @@ export const ProviderIcons = ({
       return <AliBaBaCloudIcon className={className} />
     case "llamacpp":
       return <LlamaCppLogo className={className} />
+    case "infinitenceai":
+        return <InfinigenceAI className={className} />
     default:
       return <OllamaIcon className={className} />
   }

--- a/src/components/Icons/InfinigenceAI.tsx
+++ b/src/components/Icons/InfinigenceAI.tsx
@@ -1,0 +1,19 @@
+import React from "react"
+
+export const CustomIcon = React.forwardRef<
+  SVGSVGElement,
+  React.SVGProps<SVGSVGElement>
+>((props, ref) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 25"
+      fill="none"
+      ref={ref}
+      {...props}>
+      <rect y="0.987091" width="24" height="24" rx="4" fill="white"/>
+      <path d="M13.754 18.5639V7.48907H7.25702V10.4151H10.246V18.5639H7.25702V21.4742H16.743V18.5639H13.754Z" fill="#7F1084"/>
+      <path d="M16.743 4.5H13.754V7.48895H16.743V4.5Z" fill="#2EA7E0"/>
+    </svg>
+  )
+})

--- a/src/utils/oai-api-providers.ts
+++ b/src/utils/oai-api-providers.ts
@@ -65,6 +65,11 @@ export const OAI_API_PROVIDERS = [
         baseUrl: "https://api.mistral.ai/v1"
     },
     {
+        label: "Infinigence AI",
+        value: "infinitenceai",
+        baseUrl: "https://cloud.infini-ai.com/maas/v1"
+    },
+    {
         label: "SiliconFlow",
         value: "siliconflow",
         baseUrl: "https://api.siliconflow.cn/v1"


### PR DESCRIPTION
## This PR introduces support for four new cloud providers:

[InfinigenceAI](https://cloud.infini-ai.com/genstudio/model) is an OpenAI compatible API service provider. Free models are available, for example:

1. DeepSeek R1/V3
2. QwQ-32B
3. Qwen2.5-14B-Instruct/Qwen2.5-32B-Instruct/Qwen2.5-72B-Instruct

Docs at : https://docs.infini-ai.com/gen-studio/api/

## API Details

InfinigenceAI:
Base URL: https://cloud.infini-ai.com/maas/v1
