### PR TITLE
fix: use correct translation key tooltip.clear in sidepanel

### DIFF
--- a/src/components/Sidepanel/Chat/header.tsx
+++ b/src/components/Sidepanel/Chat/header.tsx
@@ -72,7 +72,7 @@ export const SidepanelHeader = () => {
         )}
         {history.length > 0 && (
           <button
-            title={t("tooltip.clearContext")}
+            title={t("tooltip.clear")}
             onClick={() => {
               setHistory([])
             }}


### PR DESCRIPTION
The translation key tooltip.clearContext was not found in sidepanel.json, but tooltip.clear is the correct key that exists in the translation file.