### PR TITLE
Update to use newest Prompt API for Chrome

### DIFF
--- a/src/models/ChatChromeAi.ts
+++ b/src/models/ChatChromeAi.ts
@@ -10,9 +10,7 @@ import {
 import { BaseMessage, AIMessageChunk } from "@langchain/core/messages"
 import { ChatGenerationChunk } from "@langchain/core/outputs"
 import { IterableReadableStream } from "@langchain/core/utils/stream"
-import { AITextSession, checkChromeAIAvailability, createAITextSession } from "./utils/chrome"
-
-
+-import { AITextSession, checkChromeAIAvailability, createAITextSession } from "./utils/chrome"
 export interface AITextSessionOptions {
   topK: number
   temperature: number
@@ -33,7 +31,7 @@ export interface ChromeAIInputs extends BaseChatModelParams {
   promptFormatter?: (messages: BaseMessage[]) => string
 }
 
-export interface ChromeAICallOptions extends BaseLanguageModelCallOptions { }
+export interface ChromeAICallOptions extends BaseLanguageModelCallOptions {}
 
 function formatPrompt(messages: BaseMessage[]): string {
   return messages
@@ -127,7 +125,10 @@ export class ChatChromeAI extends SimpleChatModel<ChromeAICallOptions> {
 
     let previousContent = ""
     for await (const chunk of iterableStream) {
-      const newContent = chunk.slice(previousContent.length)
+      const newContent =
+        typeof (globalThis as any).LanguageModel !== "undefined"
+          ? chunk
+          : chunk.slice(previousContent.length)
       previousContent += newContent
       yield new ChatGenerationChunk({
         text: newContent,

--- a/src/models/utils/chrome.ts
+++ b/src/models/utils/chrome.ts
@@ -1,6 +1,11 @@
 
 export const checkChromeAIAvailability = async (): Promise<"readily" | "no" | "after-download"> => {
     try {
+        // latest latest newer version
+        if (typeof (globalThis as any).LanguageModel !== "undefined") {
+          const availability = await (globalThis as any).LanguageModel.availability()
+          return availability == "available" ? "readily" : "no"
+        }
         const ai = (window as any).ai;
 
         // latest i guess
@@ -37,6 +42,14 @@ export interface AITextSession {
 
 
 export const createAITextSession = async (data: any): Promise<AITextSession> => {
+
+    // even newer version
+    if (typeof (globalThis as any).LanguageModel !== "undefined") {
+        const session = await (globalThis as any).LanguageModel.create({
+            ...data
+        })
+        return session
+    }
     const ai = (window as any).ai;
 
     // new version i guess


### PR DESCRIPTION
Google plans to officially launch this for extensions in the next version of Chrome (138) so I think the API is frozen.

https://developer.chrome.com/docs/ai/prompt-api
https://github.com/webmachinelearning/prompt-api/tree/main