### PR TITLE
fix: sidebar blank screen when opening with reasoning model

### DIFF
--- a/src/components/Sidepanel/Chat/form.tsx
+++ b/src/components/Sidepanel/Chat/form.tsx
@@ -25,7 +25,7 @@ import { handleChatInputKeyDown } from "@/utils/key-down"
 import { getIsSimpleInternetSearch } from "@/services/search"
 import { useStorage } from "@plasmohq/storage/hook"
 import { useFocusShortcuts } from "@/hooks/keyboard"
-import { isThinkingCapableModel } from "~/libs/model-utils"
+import { isThinkingCapableModel, isGptOssModel } from "~/libs/model-utils"
 import { useStoreChatModelSettings } from "~/store/model"
 import { getVariable } from "@/utils/select-variable"
 


### PR DESCRIPTION
# Fix: Sidebar blank screen when opening with thinking-capable model selected

## Description

Fixes a bug provoked by me (sorry) on #754 where the sidebar would render as a blank screen when opened via keystroke (`Ctrl+Shift+Y`) with a thinking-capable model (e.g., deepseek-r1, gpt-oss) selected.

## Problem

When a user had a thinking-capable model selected and opened the sidebar using the keyboard shortcut, the component would crash and display a blank screen. This was caused by a missing import in the sidebar form component.

## Root Cause

The sidebar form (`src/components/Sidepanel/Chat/form.tsx`) was calling `isGptOssModel()` in the conditional rendering logic for the thinking mode UI, but the function was not imported from `~/libs/model-utils`.

**Error thrown:**
```
ReferenceError: isGptOssModel is not defined
```

This error crashed the React component during render, resulting in a blank screen.

## Solution

Added `isGptOssModel` to the import statement in `src/components/Sidepanel/Chat/form.tsx`:

```typescript
// Before
import { isThinkingCapableModel } from "~/libs/model-utils"

// After
import { isThinkingCapableModel, isGptOssModel } from "~/libs/model-utils"
```

## Changes

- **File modified**: `src/components/Sidepanel/Chat/form.tsx`
- **Change type**: Import statement update
- **Lines affected**: Line 28

## Testing

-  TypeScript compilation passes with no errors
-  Component now renders correctly with thinking-capable models
-  Sidebar opens properly via `Ctrl+Shift+Y` with deepseek-r1, gpt-oss, and other thinking models
-  No regression in non-thinking models

## Impact

- **Severity**: High (broken core functionality)
- **User impact**: All users attempting to use sidebar with thinking-capable models
- **Breaking changes**: None
- **Dependencies affected**: None
