### PR TITLE
feat: add sidebar position setting

### DIFF
--- a/src/assets/locale/en/settings.json
+++ b/src/assets/locale/en/settings.json
@@ -104,6 +104,13 @@
       },
       "showMoreForLargeMessage": {
         "label": "Show 'Show more' for large human messages"
+      },
+      "sidebarPosition": {
+        "label": "Sidebar Position",
+        "options": {
+          "left": "Left",
+          "right": "Right"
+        }
       }
     },
     "sidepanelRag": {

--- a/src/components/Layouts/Layout.tsx
+++ b/src/components/Layouts/Layout.tsx
@@ -18,6 +18,7 @@ import { useQueryClient } from "@tanstack/react-query"
 import { useStoreChatModelSettings } from "@/store/model"
 import { PageAssistDatabase } from "@/db/dexie/chat"
 import { useMigration } from "../../hooks/useMigration"
+import { useStorage } from "@plasmohq/storage/hook"
 
 export default function OptionLayout({
   children
@@ -28,6 +29,7 @@ export default function OptionLayout({
   const { t } = useTranslation(["option", "common", "settings"])
   const [openModelSettings, setOpenModelSettings] = useState(false)
   useMigration()
+  const [sidebarPosition] = useStorage("sidebarPosition", "left")
   const {
     setMessages,
     setHistory,
@@ -105,7 +107,7 @@ export default function OptionLayout({
               </div>
             </div>
           }
-          placement="left"
+          placement={sidebarPosition === "right" ? "right" : "left"}
           closeIcon={null}
           onClose={() => setSidebarOpen(false)}
           open={sidebarOpen}>

--- a/src/components/Option/Settings/general-settings.tsx
+++ b/src/components/Option/Settings/general-settings.tsx
@@ -117,26 +117,28 @@ export const GeneralSettings = () => {
     },
     false
   )
-    const [hideReasoningWidget, setHideReasoningWidget] = useStorage('hideReasoningWidget', false)
+  const [hideReasoningWidget, setHideReasoningWidget] = useStorage(
+    "hideReasoningWidget",
+    false
+  )
 
   const [persistChatInput, setPersistChatInput] = useStorage(
     "persistChatInput",
     false
   )
 
-  const [tableTextWrap, setTableTextWrap] = useStorage(
-    "tableTextWrap",
-    false
-  )
+  const [tableTextWrap, setTableTextWrap] = useStorage("tableTextWrap", false)
 
-  const [enableMemory, setEnableMemory] = useStorage(
-    "enableMemory",
-    false
-  )
+  const [enableMemory, setEnableMemory] = useStorage("enableMemory", false)
 
   const [showMoreForLargeMessage, setShowMoreForLargeMessage] = useStorage(
     "showMoreForLargeMessage",
     false
+  )
+
+  const [sidebarPosition, setSidebarPosition] = useStorage(
+    "sidebarPosition",
+    "left"
   )
 
   const { mode, toggleDarkMode } = useDarkMode()
@@ -568,7 +570,10 @@ export const GeneralSettings = () => {
         <div className="inline-flex items-center gap-2">
           <BetaTag />
           <span className="text-gray-700   dark:text-neutral-50">
-            {t("generalSettings.settings.enableMemory.label", "Enable Memory (Experimental)")}
+            {t(
+              "generalSettings.settings.enableMemory.label",
+              "Enable Memory (Experimental)"
+            )}
           </span>
         </div>
 
@@ -588,6 +593,31 @@ export const GeneralSettings = () => {
         <Switch
           checked={showMoreForLargeMessage}
           onChange={(checked) => setShowMoreForLargeMessage(checked)}
+        />
+      </div>
+
+      <div className="flex flex-row justify-between">
+        <span className="text-gray-700 dark:text-neutral-50 ">
+          {t("generalSettings.settings.sidebarPosition.label")}
+        </span>
+
+        <Select
+          allowClear={false}
+          style={{ width: "200px" }}
+          options={[
+            {
+              value: "left",
+              label: t("generalSettings.settings.sidebarPosition.options.left")
+            },
+            {
+              value: "right",
+              label: t("generalSettings.settings.sidebarPosition.options.right")
+            }
+          ]}
+          value={sidebarPosition}
+          onChange={(value) => {
+            setSidebarPosition(value)
+          }}
         />
       </div>
 


### PR DESCRIPTION
## Summary
This PR adds a new setting to the General Settings page that allows users to configure the position of the sidebar (Left or Right).

## Changes
- Added 'Sidebar Position' setting in `src/components/Option/Settings/general-settings.tsx`.
- Updated `src/components/Layouts/Layout.tsx` to dynamically set the `Drawer` placement based on the user's preference.
- Added translation strings in `src/assets/locale/en/settings.json`.
- Uses `useStorage` to persist the setting.

## Screenshots
(No screenshots available as I am running in a headless environment, but I have verified the build passes.)