### PR TITLE
docs: update Chrome Web Store URLs to new domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Page Assist is an open-source browser extension that provides a sidebar and web 
 
 Page Assist supports Chromium-based browsers like Chrome, Brave, and Edge, as well as Firefox.
 
-[![Chrome Web Store](https://pub-35424b4473484be483c0afa08c69e7da.r2.dev/UV4C4ybeBTsZt43U4xis.png)](https://chrome.google.com/webstore/detail/page-assist/jfgfiigpkhlkbnfnbobbkinehhfdhndo)
+[![Chrome Web Store](https://pub-35424b4473484be483c0afa08c69e7da.r2.dev/UV4C4ybeBTsZt43U4xis.png)](https://chromewebstore.google.com/detail/page-assist/jfgfiigpkhlkbnfnbobbkinehhfdhndo)
 [![Firefox Add-on](https://pub-35424b4473484be483c0afa08c69e7da.r2.dev/get-the-addon.png)](https://addons.mozilla.org/en-US/firefox/addon/page-assist/)
 [![Edge Add-on](https://pub-35424b4473484be483c0afa08c69e7da.r2.dev/edge-addon.png)](https://microsoftedge.microsoft.com/addons/detail/page-assist-a-web-ui-fo/ogkogooadflifpmmidmhjedogicnhooa)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ Page Assist makes AI interaction effortless! Simply:
 
 Download for your preferred browser:
 
-[![Chrome Web Store](https://pub-35424b4473484be483c0afa08c69e7da.r2.dev/UV4C4ybeBTsZt43U4xis.png)](https://chrome.google.com/webstore/detail/page-assist/jfgfiigpkhlkbnfnbobbkinehhfdhndo)
+[![Chrome Web Store](https://pub-35424b4473484be483c0afa08c69e7da.r2.dev/UV4C4ybeBTsZt43U4xis.png)](https://chromewebstore.google.com/detail/page-assist/jfgfiigpkhlkbnfnbobbkinehhfdhndo)
 
 [![Firefox Add-on](https://pub-35424b4473484be483c0afa08c69e7da.r2.dev/get-the-addon.png)](https://addons.mozilla.org/en-US/firefox/addon/page-assist/)
 


### PR DESCRIPTION
## Summary
- Updated 2 Chrome Web Store URLs from `chrome.google.com/webstore` to `chromewebstore.google.com` in README.md and docs/index.md
- Google migrated the Chrome Web Store to a new domain; the old URLs currently redirect but may stop working in the future

## Changes
- `README.md`: 1 URL update
- `docs/index.md`: 1 URL update

## References
- [Chrome Web Store URL migration](https://developer.chrome.com/docs/webstore/update)