### PR TITLE
feat: add CRW as search engine backend

### DIFF
--- a/src/assets/locale/en/settings.json
+++ b/src/assets/locale/en/settings.json
@@ -175,6 +175,14 @@
         "label": "Firecrawl API Key",
         "placeholder": "Enter your Firecrawl API key"
       },
+      "crwBaseURL": {
+        "label": "CRW Base URL",
+        "placeholder": "https://your-crw-instance.com"
+      },
+      "crwAPIKey": {
+        "label": "CRW API Key",
+        "placeholder": "Enter your CRW API key (optional)"
+      },
       "domainFilter": {
         "label": "Domain Filter List",
         "description": "Only show results from these domains",

--- a/src/components/Option/Settings/search-mode.tsx
+++ b/src/components/Option/Settings/search-mode.tsx
@@ -24,6 +24,8 @@ export const SearchModeSettings = () => {
       defaultInternetSearchOn: false,
       exaAPIKey: "",
       firecrawlAPIKey: "",
+      crwAPIKey: "",
+      crwBaseURL: "",
       ollamaSearchApiKey: "",
       kagiApiKey: "",
       perplexityApiKey: "",
@@ -190,6 +192,48 @@ export const SearchModeSettings = () => {
                   required
                   className="w-full mt-4 sm:mt-0 sm:w-[200px]"
                   {...form.getInputProps("firecrawlAPIKey")}
+                />
+              </div>
+            </div>
+          </>
+        )}
+
+        {form.values.searchProvider === "crw" && (
+          <>
+            <div className="flex sm:flex-row flex-col space-y-4 sm:space-y-0 sm:justify-between">
+              <span className="text-gray-700 dark:text-neutral-50">
+                {t(
+                  "generalSettings.webSearch.crwBaseURL.label",
+                  "CRW Base URL"
+                )}
+              </span>
+              <div>
+                <Input
+                  placeholder={t(
+                    "generalSettings.webSearch.crwBaseURL.placeholder",
+                    "https://your-crw-instance.com"
+                  )}
+                  required
+                  className="w-full mt-4 sm:mt-0 sm:w-[200px]"
+                  {...form.getInputProps("crwBaseURL")}
+                />
+              </div>
+            </div>
+            <div className="flex sm:flex-row flex-col space-y-4 sm:space-y-0 sm:justify-between">
+              <span className="text-gray-700 dark:text-neutral-50">
+                {t(
+                  "generalSettings.webSearch.crwAPIKey.label",
+                  "CRW API Key"
+                )}
+              </span>
+              <div>
+                <Input.Password
+                  placeholder={t(
+                    "generalSettings.webSearch.crwAPIKey.placeholder",
+                    "Enter your CRW API key (optional)"
+                  )}
+                  className="w-full mt-4 sm:mt-0 sm:w-[200px]"
+                  {...form.getInputProps("crwAPIKey")}
                 />
               </div>
             </div>

--- a/src/services/search.ts
+++ b/src/services/search.ts
@@ -136,6 +136,24 @@ export const setFirecrawlAPIKey = async (firecrawlAPIKey: string) => {
   await storage2.set("firecrawlAPIKey", firecrawlAPIKey)
 }
 
+export const getCrwAPIKey = async () => {
+  const crwAPIKey = await storage2.get("crwAPIKey")
+  return crwAPIKey || ""
+}
+
+export const setCrwAPIKey = async (crwAPIKey: string) => {
+  await storage2.set("crwAPIKey", crwAPIKey)
+}
+
+export const getCrwBaseURL = async () => {
+  const crwBaseURL = await storage2.get("crwBaseURL")
+  return crwBaseURL || ""
+}
+
+export const setCrwBaseURL = async (crwBaseURL: string) => {
+  await storage2.set("crwBaseURL", crwBaseURL)
+}
+
 export const getExaAPIKey = async () => {
   const exaAPIKey = await storage2.get("exaAPIKey")
   return exaAPIKey || ""
@@ -215,6 +233,8 @@ export const getSearchSettings = async () => {
     defaultInternetSearchOn,
     exaAPIKey,
     firecrawlAPIKey,
+    crwAPIKey,
+    crwBaseURL,
     ollamaSearchApiKey,
     kagiApiKey,
     perplexityApiKey,
@@ -233,6 +253,8 @@ export const getSearchSettings = async () => {
     getInternetSearchOn(),
     getExaAPIKey(),
     getFirecrawlAPIKey(),
+    getCrwAPIKey(),
+    getCrwBaseURL(),
     getOllamaSearchApiKey(),
     getKagiApiKey(),
     getPerplexityApiKey(),
@@ -253,6 +275,8 @@ export const getSearchSettings = async () => {
     defaultInternetSearchOn,
     exaAPIKey,
     firecrawlAPIKey,
+    crwAPIKey,
+    crwBaseURL,
     ollamaSearchApiKey,
     kagiApiKey,
     perplexityApiKey,
@@ -274,6 +298,8 @@ export const setSearchSettings = async ({
   defaultInternetSearchOn,
   exaAPIKey,
   firecrawlAPIKey,
+  crwAPIKey,
+  crwBaseURL,
   ollamaSearchApiKey,
   kagiApiKey,
   perplexityApiKey,
@@ -292,6 +318,8 @@ export const setSearchSettings = async ({
   defaultInternetSearchOn: boolean
   exaAPIKey: string
   firecrawlAPIKey: string
+  crwAPIKey: string
+  crwBaseURL: string
   ollamaSearchApiKey: string
   kagiApiKey: string
   perplexityApiKey: string
@@ -311,6 +339,8 @@ export const setSearchSettings = async ({
     setInternetSearchOn(defaultInternetSearchOn),
     setExaAPIKey(exaAPIKey),
     setFirecrawlAPIKey(firecrawlAPIKey),
+    setCrwAPIKey(crwAPIKey),
+    setCrwBaseURL(crwBaseURL),
     setOllamaSearchApiKey(ollamaSearchApiKey),
     setKagiApiKey(kagiApiKey),
     setPerplexityApiKey(perplexityApiKey),

--- a/src/utils/search-provider.ts
+++ b/src/utils/search-provider.ts
@@ -52,6 +52,10 @@ export const SUPPORTED_SEARCH_PROVIDERS = [
         value: "firecrawl"
     },
     {
+        label: "CRW",
+        value: "crw"
+    },
+    {
         label: "Ollama Web search",
         value: "ollama-search"
     },

--- a/src/web/search-engines/crw.ts
+++ b/src/web/search-engines/crw.ts
@@ -102,11 +102,16 @@ const apiCrwSearch = async (
 ) => {
     const TOTAL_SEARCH_RESULTS = await totalSearchResults()
 
-    const normalizedBase = baseURL.replace(/\/+$/, "")
-    const searchURL = `${normalizedBase}/v1/search`
+    const trimmedBase = baseURL.trim()
+    const cleanedBase = cleanUrl(trimmedBase)
+    const baseWithoutTrailingSlash = cleanedBase.replace(/\/+$/, "")
+    const normalizedBase = baseWithoutTrailingSlash.endsWith("/v1")
+        ? baseWithoutTrailingSlash
+        : `${baseWithoutTrailingSlash}/v1`
+    const searchURL = `${normalizedBase}/search`
 
     const abortController = new AbortController()
-    setTimeout(() => abortController.abort(), 20000)
+    const timeoutId = setTimeout(() => abortController.abort(), 20000)
 
     const headers: Record<string, string> = {
         Accept: "application/json",
@@ -146,5 +151,7 @@ const apiCrwSearch = async (
     } catch (error) {
         console.error("CRW API search failed:", error)
         return []
+    } finally {
+        clearTimeout(timeoutId)
     }
 }

--- a/src/web/search-engines/crw.ts
+++ b/src/web/search-engines/crw.ts
@@ -1,0 +1,150 @@
+import { cleanUrl } from "~/libs/clean-url"
+import {
+    getIsSimpleInternetSearch,
+    totalSearchResults,
+    getCrwAPIKey,
+    getCrwBaseURL
+} from "@/services/search"
+import { pageAssistEmbeddingModel } from "@/models/embedding"
+import type { Document } from "@langchain/core/documents"
+import { MemoryVectorStore } from "@langchain/classic/vectorstores/memory"
+import { PageAssistHtmlLoader } from "@/loader/html"
+import {
+    defaultEmbeddingModelForRag,
+    getOllamaURL,
+    getSelectedModel
+} from "~/services/ollama"
+import { getPageAssistTextSplitter } from "@/utils/text-splitter"
+
+interface CrwSearchResult {
+    title: string
+    url: string
+    description: string
+    markdown: string
+}
+
+interface CrwSearchResponse {
+    data: CrwSearchResult[]
+}
+
+export const crwAPISearch = async (query: string) => {
+    const crwAPIKey = await getCrwAPIKey()
+    const crwBaseURL = await getCrwBaseURL()
+
+    if (!crwBaseURL || crwBaseURL.trim() === "") {
+        throw new Error("CRW base URL not configured")
+    }
+
+    const results = await apiCrwSearch(crwBaseURL, crwAPIKey, query)
+    const TOTAL_SEARCH_RESULTS = await totalSearchResults()
+
+    const searchResults = results.slice(0, TOTAL_SEARCH_RESULTS)
+
+    const isSimpleMode = await getIsSimpleInternetSearch()
+
+    if (isSimpleMode) {
+        await getOllamaURL()
+        return searchResults.map((result) => {
+            return {
+                url: result.link,
+                content: result.content
+            }
+        })
+    }
+
+    const docs: Document<Record<string, any>>[] = []
+    try {
+        for (const result of searchResults) {
+            const loader = new PageAssistHtmlLoader({
+                html: "",
+                url: result.link
+            })
+
+            const documents = await loader.loadByURL()
+            documents.forEach((doc) => {
+                docs.push(doc)
+            })
+        }
+    } catch (error) {
+        console.error(error)
+    }
+
+    const ollamaUrl = await getOllamaURL()
+    const embeddingModel = await defaultEmbeddingModelForRag()
+    const selectedModel = await getSelectedModel()
+    const ollamaEmbedding = await pageAssistEmbeddingModel({
+        model: embeddingModel || selectedModel || "",
+        baseUrl: cleanUrl(ollamaUrl)
+    })
+
+    const textSplitter = await getPageAssistTextSplitter()
+
+    const chunks = await textSplitter.splitDocuments(docs)
+    const store = new MemoryVectorStore(ollamaEmbedding)
+    await store.addDocuments(chunks)
+
+    const resultsWithEmbeddings = await store.similaritySearch(query, 3)
+
+    const searchResult = resultsWithEmbeddings.map((result) => {
+        return {
+            url: result.metadata.url,
+            content: result.pageContent
+        }
+    })
+
+    return searchResult
+}
+
+const apiCrwSearch = async (
+    baseURL: string,
+    apiKey: string,
+    query: string
+) => {
+    const TOTAL_SEARCH_RESULTS = await totalSearchResults()
+
+    const normalizedBase = baseURL.replace(/\/+$/, "")
+    const searchURL = `${normalizedBase}/v1/search`
+
+    const abortController = new AbortController()
+    setTimeout(() => abortController.abort(), 20000)
+
+    const headers: Record<string, string> = {
+        Accept: "application/json",
+        "Content-Type": "application/json"
+    }
+
+    if (apiKey && apiKey.trim() !== "") {
+        headers["Authorization"] = `Bearer ${apiKey}`
+    }
+
+    try {
+        const response = await fetch(searchURL, {
+            signal: abortController.signal,
+            method: "POST",
+            headers,
+            body: JSON.stringify({
+                limit: TOTAL_SEARCH_RESULTS,
+                lang: "",
+                country: "",
+                timeout: 60000,
+                scrapeOptions: { formats: [] },
+                query: query
+            })
+        })
+
+        if (!response.ok) {
+            return []
+        }
+
+        const data = (await response.json()) as CrwSearchResponse
+
+        return data?.data.map((result) => ({
+            title: result.title,
+            link: result.url,
+            content: result.description
+        }))
+    } catch (error) {
+        console.error("CRW API search failed:", error)
+        return []
+    }
+}

--- a/src/web/web.ts
+++ b/src/web/web.ts
@@ -14,6 +14,7 @@ import { stractSearch } from "./search-engines/stract"
 import { startpageSearch } from "./search-engines/startpage"
 import { exaAPISearch } from "./search-engines/exa"
 import { firecrawlAPISearch } from "./search-engines/firecrawl"
+import { crwAPISearch } from "./search-engines/crw"
 import { ollamaAPISearch } from "./search-engines/ollama"
 import { kagiAPISearch } from "./search-engines/kagi-api"
 import { perplexityAPISearch } from "./search-engines/perplexity-api"
@@ -65,6 +66,8 @@ const searchWeb = (provider: string, query: string) => {
       return exaAPISearch(query)
     case "firecrawl":
       return firecrawlAPISearch(query)
+    case "crw":
+      return crwAPISearch(query)
     case "ollama-search":
       return ollamaAPISearch(query)
     case "kagi-api":


### PR DESCRIPTION
## Summary

- Add [CRW](https://github.com/us/crw) as a new web search engine backend option
- CRW is an open-source, Firecrawl-compatible web scraper that can be self-hosted or used via cloud ([fastcrw.com](https://fastcrw.com))
- Configuration includes a base URL (required) and an API key (optional), making it suitable for both self-hosted and cloud deployments

## Changes

- `src/web/search-engines/crw.ts` — new search engine backend using CRW's Firecrawl-compatible `/v1/search` API
- `src/web/web.ts` — register CRW in the search provider switch
- `src/utils/search-provider.ts` — add CRW to the supported providers list
- `src/services/search.ts` — add get/set functions for CRW API key and base URL, wire into settings
- `src/components/Option/Settings/search-mode.tsx` — add CRW settings UI (base URL + optional API key)
- `src/assets/locale/en/settings.json` — add English locale strings for CRW settings

## Test plan

- [ ] Select "CRW" from the search provider dropdown in Settings
- [ ] Verify base URL field appears and is required
- [ ] Verify API key field appears and is optional
- [ ] Configure a CRW instance URL and perform a web search query
- [ ] Verify search results are returned and displayed correctly
- [ ] Test with both simple and embedding-based search modes