### PR TITLE
feat: add z.ai as an OpenAI-compatible provider

### DIFF
--- a/src/components/Common/ProviderIcon.tsx
+++ b/src/components/Common/ProviderIcon.tsx
@@ -26,6 +26,7 @@ import { ChutesIcon } from "../Icons/ChutesIcon"
 import { AnthropicIcon } from "../Icons/AnthropicIcon"
 import { AtlasCloudIcon } from "../Icons/AtlasCloud"
 import { BigModelZhipuIcon } from "../Icons/BigModelZhipuIcon"
+import { ZAiIcon } from "../Icons/ZAiIcon"
 import { CanopyWaveIcon } from "../Icons/CanopyWaveIcon"
 import { MiniMaxIcon } from "../Icons/MiniMaxIcon"
 import { XiaomiMimoIcon } from "../Icons/XiaomiMimo"
@@ -99,6 +100,8 @@ export const ProviderIcons = ({
       return <CanopyWaveIcon className={className} />
     case 'zhipu':
       return <BigModelZhipuIcon className={className} />
+    case 'zai':
+      return <ZAiIcon className={className} />
     case 'minimax':
       return <MiniMaxIcon className={className} />
     case 'xiaomimimo':

--- a/src/components/Icons/ZAiIcon.tsx
+++ b/src/components/Icons/ZAiIcon.tsx
@@ -1,0 +1,40 @@
+import React from "react"
+
+export const ZAiIcon = React.forwardRef<
+  SVGSVGElement,
+  React.SVGProps<SVGSVGElement>
+>((props, ref) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 160 160"
+      ref={ref}
+      {...props}
+    >
+      <g clipPath="url(#clip0_zai)">
+        <path
+          fill="#000"
+          d="M137.381 0H22.619C10.1269 0 0 10.1269 0 22.619V137.381C0 149.873 10.1269 160 22.619 160H137.381C149.873 160 160 149.873 160 137.381V22.619C160 10.1269 149.873 0 137.381 0Z"
+        />
+        <path
+          fill="#fff"
+          d="M82.771 33.208 75.066 44.157c-.605.86-1.408 1.563-2.341 2.049a8.04 8.04 0 0 1-3.02.944H27.71V33.163z"
+        />
+        <path
+          fill="#fff"
+          d="M135.083 33.208 68.983 126.837H24.917L91.017 33.208z"
+        />
+        <path
+          fill="#fff"
+          d="M77.274 126.837 85.024 115.843c.608-.855 1.412-1.551 2.345-2.029a8.04 8.04 0 0 1 3.017-.719h41.949v13.517z"
+        />
+      </g>
+      <defs>
+        <clipPath id="clip0_zai">
+          <rect width="160" height="160" fill="#fff" />
+        </clipPath>
+      </defs>
+    </svg>
+  )
+})

--- a/src/utils/oai-api-providers.ts
+++ b/src/utils/oai-api-providers.ts
@@ -150,6 +150,11 @@ export const OAI_API_PROVIDERS = [
     baseUrl: 'https://open.bigmodel.cn/api/paas/v4'
   },
   {
+    label: 'z.ai',
+    value: 'zai',
+    baseUrl: 'https://api.z.ai/api/paas/v4'
+  },
+  {
     label: 'MiniMax',
     value: 'minimax',
     baseUrl: 'https://api.minimax.io/v1'

--- a/src/utils/oai-api-providers.ts
+++ b/src/utils/oai-api-providers.ts
@@ -150,7 +150,7 @@ export const OAI_API_PROVIDERS = [
     baseUrl: 'https://open.bigmodel.cn/api/paas/v4'
   },
   {
-    label: 'z.ai',
+    label: 'z.ai (Zhipu)',
     value: 'zai',
     baseUrl: 'https://api.z.ai/api/paas/v4'
   },


### PR DESCRIPTION
## Summary

Adds [z.ai](https://z.ai) — Zhipu's **international** API endpoint — as a built-in OpenAI-compatible provider.

This is distinct from the existing **BigModel (Zhipu)** entry, which points to the Chinese endpoint (`open.bigmodel.cn`). z.ai uses the international endpoint `api.z.ai`.

**Base URL:** `https://api.z.ai/api/paas/v4`

## Changes
- `src/utils/oai-api-providers.ts` — new provider entry `{ label: 'z.ai', value: 'zai', baseUrl: 'https://api.z.ai/api/paas/v4' }` (placed alongside the existing `zhipu` entry).
- `src/components/Icons/ZAiIcon.tsx` — new icon component using the official z.ai logo.
- `src/components/Common/ProviderIcon.tsx` — wire the `zai` provider id to the new icon.

## Verification
- Built the Firefox extension (`bun run build:firefox`); `web-ext lint` reports **0 errors**.
- The provider appears in the model-provider dropdown with its icon.
- Verified the endpoint end-to-end against the live API:
  - `POST /chat/completions` returns valid completions (tested `glm-4.5-flash`).
  - `GET /models` returns: `glm-4.5`, `glm-4.5-air`, `glm-4.6`, `glm-4.7`, `glm-5`, `glm-5-turbo`, `glm-5.1`, `glm-5.2`.