### PR TITLE
feat: add note to myself mode

### DIFF
--- a/src/assets/locale/en/common.json
+++ b/src/assets/locale/en/common.json
@@ -150,7 +150,8 @@
         "explain": "Explain",
         "rephrase": "Rephrase",
         "translate": "Translate",
-        "custom": "Custom"
+        "custom": "Custom",
+        "note": "Note"
     },
     "citations": "Citations",
     "segmented": {

--- a/src/components/Common/ModelSelect.tsx
+++ b/src/components/Common/ModelSelect.tsx
@@ -11,9 +11,17 @@ type Props = {
   iconClassName?: string
 }
 
-export const ModelSelect: React.FC<Props> = ({iconClassName = "size-5"}) => {
+export const ModelSelect: React.FC<Props> = ({
+  iconClassName = "size-5"
+}) => {
   const { t } = useTranslation("common")
-  const { setSelectedModel, selectedModel } = useMessage()
+
+  const {
+    setSelectedModel,
+    selectedModel,
+    setChatMode
+  } = useMessage()
+
   const { data } = useQuery({
     queryKey: ["getAllModelsForSelect"],
     queryFn: async () => {
@@ -27,14 +35,18 @@ export const ModelSelect: React.FC<Props> = ({iconClassName = "size-5"}) => {
       {data && data.length > 0 && (
         <Dropdown
           menu={{
-            items:
-              data?.map((d) => ({
+            items: [
+              ...(data?.map((d) => ({
                 key: d.name,
                 label: (
-                  <div className="w-52 gap-2 text-lg truncate inline-flex line-clamp-3  items-center  dark:border-gray-700">
+                  <div className="w-52 gap-2 text-lg truncate inline-flex line-clamp-3 items-center dark:border-gray-700">
                     <div>
                       {d.avatar ? (
-                        <Avatar src={d.avatar} alt={d.name} size="small" />
+                        <Avatar
+                          src={d.avatar}
+                          alt={d.name}
+                          size="small"
+                        />
                       ) : (
                         <ProviderIcons
                           provider={d?.provider}
@@ -42,28 +54,53 @@ export const ModelSelect: React.FC<Props> = ({iconClassName = "size-5"}) => {
                         />
                       )}
                     </div>
+
                     {d?.nickname || d.model}
                   </div>
                 ),
+
                 onClick: () => {
+                  // Switch back to normal AI chat
+                  setChatMode("normal")
+
                   if (selectedModel === d.model) {
                     setSelectedModel(null)
                   } else {
                     setSelectedModel(d.model)
                   }
                 }
-              })) || [],
+              })) || []),
+
+              {
+                type: "divider"
+              },
+
+              {
+                key: "note",
+                label: "Note to myself",
+
+                onClick: () => {
+                  setChatMode("note")
+                }
+              }
+            ],
+
             style: {
               maxHeight: 500,
               overflowY: "scroll"
             },
+
             className: "no-scrollbar",
             activeKey: selectedModel
           }}
           placement={"topLeft"}
-          trigger={["click"]}>
+          trigger={["click"]}
+        >
           <Tooltip title={t("selectAModel")}>
-            <button type="button" className="dark:text-gray-300">
+            <button
+              type="button"
+              className="dark:text-gray-300"
+            >
               <LucideBrain className={iconClassName} />
             </button>
           </Tooltip>

--- a/src/components/Sidepanel/Chat/form.tsx
+++ b/src/components/Sidepanel/Chat/form.tsx
@@ -276,6 +276,7 @@ export const SidepanelForm = ({ dropedFile }: Props) => {
     }
   })
   const validateBeforeMessageSend = async () => {
+    if (chatMode === "note") return true
     if (!selectedModel || selectedModel.length === 0) {
       form.setFieldError("message", t("formError.noModel"))
       return false

--- a/src/hooks/useMessage.tsx
+++ b/src/hooks/useMessage.tsx
@@ -17,7 +17,10 @@ import {
   generateID,
   getPromptById,
   removeMessageUsingHistoryId,
-  updateMessageByIndex
+  updateMessageByIndex,
+  saveMessage,
+  saveHistory,
+  updateChatHistoryCreatedAt
 } from "@/db/dexie/helpers"
 import { notification } from "antd"
 import { useTranslation } from "react-i18next"
@@ -1681,6 +1684,54 @@ export const useMessage = () => {
     chatType?: string
     docs?: ChatDocuments
   }) => {
+    if (chatMode === "note") {
+      const noteMessage: Message = {
+        isBot: false,
+        name: "You",
+        message,
+        sources: [],
+        images: image ? [image] : images || [],
+        id: generateID(),
+        createdAt: Date.now(),
+        messageType: "note"
+      }
+      setMessages([...(chatHistory || messages), noteMessage])
+
+      // Note: intentionally not added to `history` (ChatHistory) — that
+      // array is what gets sent to the AI as conversation context, and
+      // notes must stay invisible to the AI per #746.
+      if (!temporaryChat) {
+        try {
+          let noteHistoryId = historyId
+          if (!noteHistoryId) {
+            const newHistory = await saveHistory(
+              message.slice(0, 50) || "Note",
+              false,
+              "web-ui"
+            )
+            noteHistoryId = newHistory.id
+            setHistoryId(noteHistoryId)
+          }
+          await saveMessage({
+            history_id: noteHistoryId,
+            name: "note",
+            role: "user",
+            content: message,
+            images: noteMessage.images,
+            time: 1,
+            message_type: "note"
+          })
+          await updateChatHistoryCreatedAt(noteHistoryId)
+        } catch (e) {
+          console.error("Failed to save note to history:", e)
+        }
+      } else {
+        setHistoryId("temp")
+      }
+
+      return
+    }
+
     let signal: AbortSignal
     if (!controller) {
       const newController = new AbortController()

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -52,8 +52,8 @@ type State = {
   setIsProcessing: (isProcessing: boolean) => void
   selectedModel: string | null
   setSelectedModel: (selectedModel: string) => void
-  chatMode: "normal" | "rag" | "vision"
-  setChatMode: (chatMode: "normal" | "rag" | "vision") => void
+  chatMode: "normal" | "rag" | "vision" | "note"
+ setChatMode: (chatMode: "normal" | "rag" | "vision" | "note") => void
   isEmbedding: boolean
   setIsEmbedding: (isEmbedding: boolean) => void
   speechToTextLanguage: string

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -3,5 +3,6 @@ export const tagColors = {
   explain: "green",
   translate: "purple",
   custom: "orange",
-  rephrase: "yellow"
+  rephrase: "yellow",
+  note: "cyan"
 }


### PR DESCRIPTION
## Summary

- Add a "Note to myself" option at the bottom of the AI model dropdown
- Allow users to write notes without sending a request to an AI provider
- Keep notes out of the AI conversation context
- Persist notes in chat history, reusing existing Dexie helpers (no new storage system)
- Restore notes when reopening a saved chat
- Respect existing Temporary Chat setting (notes aren't persisted when enabled)
- Keep normal AI chat behavior unchanged
- Scope: Side Panel only

## Testing

- Created a note and confirmed no request was sent to Ollama (checked network tab)
- Confirmed the note appears in the conversation with a distinct visual tag
- Reopened the chat from history and confirmed the note persisted
- Sent a normal message afterward and confirmed the note wasn't included in the AI's context
- Switched back to a real model and confirmed normal Ollama responses still work
- No new TypeScript errors introduced

## Screenshots

<img width="1124" height="704" alt="image" src="https://github.com/user-attachments/assets/224fe401-8b4f-4eda-b319-ca658b2ac882" />

Fixes #746