### PR TITLE
feat: add llmman to the OpenAI-compatible providers

### DIFF
--- a/src/components/Common/ProviderIcon.tsx
+++ b/src/components/Common/ProviderIcon.tsx
@@ -54,6 +54,11 @@ export const ProviderIcons = ({
       return <GroqMonoIcon className={className} />
     case "lmstudio":
       return <LMStudioIcon className={className} />
+    // No llmman mark available, so fall back to the same neutral icon as
+    // "custom" rather than the default branch, which would show another
+    // provider's logo.
+    case "llmman":
+      return <CpuIcon className={className} />
     case "openai":
       return <OpenAiIcon className={className} />
     case "together":

--- a/src/components/Option/Settings/openai.tsx
+++ b/src/components/Option/Settings/openai.tsx
@@ -31,7 +31,7 @@ import { OpenAIFetchModel } from "./openai-fetch-model"
 import { OAI_API_PROVIDERS } from "@/utils/oai-api-providers"
 import { ProviderIcons } from "@/components/Common/ProviderIcon"
 import { buildVertexBaseUrl } from "@/libs/vertex-auth"
-const noPopupProvider = ["lmstudio", "llamafile", "ollama2", "llamacpp", "vllm"]
+const noPopupProvider = ["lmstudio", "llamafile", "ollama2", "llamacpp", "vllm", "llmman"]
 import { isFireFoxPrivateMode } from "@/utils/is-private-mode"
 import { setProviderState, getAllProviderStates } from "@/db/dexie/providerState"
 import { useState as useReactState, useEffect } from "react"

--- a/src/utils/oai-api-providers.ts
+++ b/src/utils/oai-api-providers.ts
@@ -25,6 +25,11 @@ export const OAI_API_PROVIDERS = [
     baseUrl: "http://127.0.0.1:8080/v1"
   },
   {
+    label: "llmman",
+    value: "llmman",
+    baseUrl: "http://localhost:17434/v1"
+  },
+  {
     label: "Ollama",
     value: "ollama2",
     baseUrl: "http://localhost:11434/v1"


### PR DESCRIPTION
Adds [llmman](https://github.com/llmmanorg/llmman), which runs local models distributed as OCI artifacts and serves an OpenAI-compatible API on port 17434.

Three small changes:

- an entry in `OAI_API_PROVIDERS`, placed case-insensitively alphabetically between `Llamafile` and `Ollama` to match the ordering at the top of that list
- added to `noPopupProvider`, since like the other local runners it needs no API key
- an explicit `case "llmman"` in `ProviderIcon`

That last one is worth a sentence. There's no llmman mark among the existing icon components, and `ProviderIcon`'s `default:` branch returns `<OllamaIcon />` — so without an explicit case, llmman would render **another provider's logo**, which seemed worse than a generic one. I pointed it at `<CpuIcon />`, the same neutral icon `"custom"` uses. Happy to swap in a real mark if you'd like one added.

**Testing:** `tsc --noEmit` reports 3196 lines both before and after, verified against a stashed baseline, so nothing introduced. (The absolute number is high because I typechecked without installing dependencies; the delta is the meaningful part.)

Not verified: no run of the extension against a live server, so the settings UI and a real completion are untested.

> AI-assisted, reviewed before submitting.
